### PR TITLE
Extract file trimming function and implement in MCTA key generation

### DIFF
--- a/code/data_exporting.py
+++ b/code/data_exporting.py
@@ -150,11 +150,9 @@ class OutputSheet():
         """Removes the extra headings from the heading row and replaces blank
         cells with `replace_empty_with`. Pads any short rows with that value to
         make all rows the same length. """
-        # Finds the length of the longest row by subtracting the smallest index
-        # of the first element in a row that is not blank from the length of the
-        # header row.
+        # Finds the length of the longest row by subtracting the minimum number of trailing empty elements
         longest_length = len(self.data[0]) - min([
-            next((i for i, ans in enumerate(reversed(row)) if ans != ""), 0)
+            list_utils.count_trailing_empty_elements(row)
             for row in self.data[1:]
         ])
         self.data[0] = self.data[0][:longest_length]

--- a/code/list_utils.py
+++ b/code/list_utils.py
@@ -130,3 +130,8 @@ def transpose(matrix: tp.List[tp.List[T]]) -> tp.List[tp.List[T]]:
             "Input matrix rows must all have the same length for transposing.")
     return [[row[col_index] for row in matrix]
             for col_index in range(len(matrix[0]))]
+
+
+def count_trailing_empty_elements(items: tp.List[tp.Any]) -> int:
+    """Returns the number of trailing empty elements in the list."""
+    return next((i for i, x in enumerate(reversed(items)) if x != ""), len(items))

--- a/code/mcta_processing.py
+++ b/code/mcta_processing.py
@@ -4,6 +4,7 @@ import datetime
 import itertools
 
 from data_exporting import format_timestamp_for_file, save_csv, OutputSheet
+import list_utils
 
 """Support for additional outputs used by the Multiple Choice Test Analysis software."""
 
@@ -70,8 +71,9 @@ def build_key_csv(answers: tp.List[str]) -> tp.List[tp.List[str]]:
     Params:
         answers: All of the answers for this form code, in order.
     """
+    length = len(answers) - list_utils.count_trailing_empty_elements(answers)
     header = ["", "Answer", "Title", "Concept"]
-    data = [[f"Q{i}", x, f"Q{i}", "unknown"] for i, x in enumerate(answers, 1)]
+    data = [[f"Q{i}", x, f"Q{i}", "unknown"] for i, x in enumerate(answers[:length], 1)]
     return [header] + data
 
 


### PR DESCRIPTION
Fixes #49 by trimming empty values off the end of answer keys before writing to file.