### PR TITLE
Fix startup error on Linux by only setting TKinter window icon on Windows 

### DIFF
--- a/code/user_interface.py
+++ b/code/user_interface.py
@@ -6,6 +6,7 @@ import sys
 import tkinter as tk
 from tkinter import filedialog, ttk
 import typing as tp
+import platform
 
 import file_handling
 import scoring
@@ -460,8 +461,12 @@ class MainWindow:
         self.__app = app
         app.title(f"{APP_NAME} - Select Inputs")
 
-        iconpath = str(Path(__file__).parent / "assets" / "icon.ico")
-        app.iconbitmap(iconpath)
+        # Only windows supports ICO files. Linux and macOS support XBM files, but they are single-
+        # color and not that pretty so we just don't set an icon on other platforms. It's a minor
+        # UX thing that most people will never notice.
+        if platform.system() == "Windows":
+            iconpath = str(Path(__file__).parent / "assets" / "icon.ico")
+            app.iconbitmap(iconpath)
 
         app.protocol("WM_DELETE_WINDOW", self.__on_close)
 

--- a/readme.md
+++ b/readme.md
@@ -41,13 +41,15 @@ does not require administrator priveleges.
 
 If you wish to customize the software or you need to run it on a non-Windows
 device, you can run the Python program directly from the source files. This
-requires Python to be installed on your machine. Download
-the latest `Source code (zip)` file from [releases](https://github.com/iansan5653/open-mcr/releases).
-Extract the file and open a terminal / command prompt in the extracted directory.
-Run the command `python code/main.py`.
+requires Python and Pip to be installed on your machine.
 
-_Note_: This software has not been tested on other operating systems and support
-is not guarunteed. If you find a bug, please file an [issue](https://github.com/iansan5653/open-mcr/issues).
+1. Clone the reposotory using Git, or download and extract the latest `Source code (zip)` file from
+  [releases](https://github.com/iansan5653/open-mcr/releases).
+2. Open a terminal / command prompt in the extracted directory.
+3. Run `pip3 install -r requirements.txt` (or `pip` if that's the name of Python 3 Pip on your
+  machine).
+4. If you are using linux, you may also need to `apt install` `python3-opencv` and `python3-tk`.
+5. Run `python3 code/main.py` (or `python code/main.py`).
 
 ## Printable Multiple Choice Sheet
 


### PR DESCRIPTION
The .ico file used for the window icon is only compatible with Windows operating systems. Unix based OSes use .xbm files. We might eventually add an XBM file for those machines, but for now it's a minor UI impact to just disable the window icon there so that Linux users can start the app. Fixes #41.

Also expands startup instructions to add more details for both Windows and Unix.

**Note**: I am unable to test this as I am running Windows. The app does seem to start on my WSL installation, but WSL doesn't support GUIs so I can't actually test it thoroughly. @ayalcin1995 or anyone with Linux / Mac - could you verify that the fix works before I merge this?